### PR TITLE
bugfix: wrong head string ending position

### DIFF
--- a/src/flbwt.cpp
+++ b/src/flbwt.cpp
@@ -192,7 +192,7 @@ flbwt::Container *flbwt::extract_LMS_strings(uint8_t *T, const uint64_t n)
     // The next to last character is always of TYPE_L.
     // Each S* substring in T can be denoted as T[p...q].
     int previous_type = TYPE_L;
-    uint64_t p = 0;
+    uint64_t p = n;
     uint64_t q = n;
     ++container->M[0];
     ++container->M[T[n - 1] + 1];


### PR DESCRIPTION
Fixed a bug where head string ending position was assigned wrong value. This happened when the input string did not have any other LMS-substring than the end substring T[n].